### PR TITLE
Deployment Docs - Added fallback command to update PGP keys

### DIFF
--- a/docs/deployment/deploying-ubuntu.md
+++ b/docs/deployment/deploying-ubuntu.md
@@ -11,7 +11,7 @@
 
 ```bash
 sudo echo "deb [arch=amd64] http://ubuntu.openvidu.io/6.10.0 xenial kms6" | sudo tee /etc/apt/sources.list.d/kurento.list
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5AFA7A83
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5AFA7A83 || sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 5AFA7A83
 sudo apt-get update
 sudo apt-get -y install kurento-media-server
 ```


### PR DESCRIPTION
PGP keys update command fails on Xenial 16.04
Openvidu - Kurento TEAM <openvidu@gmail.com> are not getting updated on Ubuntu Xenial on our production server.