### PR TITLE
Adds -Dopenvidu.publicurl argument

### DIFF
--- a/docs/deployment/deploying-ubuntu.md
+++ b/docs/deployment/deploying-ubuntu.md
@@ -154,7 +154,7 @@ In order to use your JKS, just give the proper value to the following OpenVidu S
 ##### Example
 
 ```bash
-java -jar -Dopenvidu.secret=MY_SECRET -Dserver.ssl.key-store=/opt/openvidu/my_keystore.jks -Dserver.ssl.key-store-password=MY_KEYSTORE_SECRET -Dserver.ssl.key-alias=my_cert_alias openvidu-server-2.5.0.jar
+java -jar -Dopenvidu.secret=MY_SECRET -Dopenvidu.publicurl=https://YOUR_MACHINE_PUBLIC_IP:4443/ -Dserver.ssl.key-store=/opt/openvidu/my_keystore.jks -Dserver.ssl.key-store-password=MY_KEYSTORE_SECRET -Dserver.ssl.key-alias=my_cert_alias openvidu-server-2.5.0.jar
 ```
 
 > Remember we provide a super simple way of using a **FREE**, **AUTOMATIC** and 100% **VALID** certificate thanks to Let's Encrypt technology: when deploying your CloudFormation Stack, just fill in the form fields with the values from the column **[LET'S ENCRYPT CERTIFICATE](deployment/deploying-aws#4-specify-stack-details){:target="_blank"}**


### PR DESCRIPTION
Adds the public url argument to the keystore example
`-Dopenvidu.publicurl=https://YOUR_MACHINE_PUBLIC_IP:4443/`
Following this guide i got stuck here because the Test site wasn't working anymore