### PR TITLE
Clear current user context when changing to root

### DIFF
--- a/docs/deployment/deploying-on-premises.md
+++ b/docs/deployment/deploying-on-premises.md
@@ -55,7 +55,7 @@ This procedure installs the following services:
 You need root permissions to deploy OpenVidu.
 
 ```bash
-sudo su
+sudo su -
 ```
 
 The recommended folder to install OpenVidu is **`/opt`**. Every other instruction in the documentation regarding on premises deployment assumes this installation path.


### PR DESCRIPTION
Even tho the next documented command is `cd /opt`, changing to root with `sudo su` will keep the current user context, like the current user dir (and other stuffs). By using `-` it will clear the current user context, and the current dir will be the root's home dir. This is a cleaner approach when changing to root.