### PR TITLE
Change to new API methods for Kurento release 6.18.0

### DIFF
--- a/docs/openvidu-pro/monitoring-elastic-stack.md
+++ b/docs/openvidu-pro/monitoring-elastic-stack.md
@@ -314,7 +314,7 @@ All events of OpenVidu are stored in the index `openvidu`, which have an `elasti
   "user": "09847CC560698063",
   "connectionId": "con_Sazh73ER9L",
   "endpoint": "str_CAM_GdhM_con_Sazh73ER9L",
-  "type": "MediaFlowOutStateChange",
+  "type": "MediaFlowOutStateChanged",
   "state": "FLOWING",
   "padName": "default",
   "mediaType": "VIDEO",


### PR DESCRIPTION
The old names become deprecated since Kurento 6.18, and will be
definitely removed in Kurento 7.0

* Old: MediaFlowOutStateChange
  New: MediaFlowOutStateChanged

* Old: MediaFlowInStateChange
  New: MediaFlowInStateChanged

* Old: MediaTranscodingStateChange
  New: MediaTranscodingStateChanged

* Old: OnIceCandidate
  New: IceCandidateFound

* Old: OnIceGatheringDone
  New: IceGatheringDone

* Old: OnIceComponentStateChanged, IceComponentStateChanges
  New: IceComponentStateChanged

* Old: OnDataChannelOpened, DataChannelOpens
  New: DataChannelOpened

* Old: OnDataChannelClosed, DataChannelClose
  New: DataChannelClosed